### PR TITLE
Setup docker compose

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=password

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+qdrant_data/
+neo4j_data/
+tts/
+ollama/
+__pycache__/
+*.pyc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,6 @@ These instructions apply to the entire repository.
 - Cache packages during tests when possible to avoid redundant downloads.
 - Provide thorough inline documentation and examples in the code.
 - Update this file with lessons learned or reminders as the project evolves.
+
+- Ensure local volume directories (qdrant_data, neo4j_data, tts, ollama) exist but remain gitignored.
+- Make scripts executable.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+services:
+  tts:
+    image: ghcr.io/coqui-ai/tts
+    ports:
+      - "5002:5002"
+    entrypoint: python3
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - COQUI_TOS_AGREED=1
+      - TTS_MODEL="tts_models/en/ljspeech/tacotron2-DDC"
+      - VOCODER_MODEL="vocoder_models/en/ljspeech/hifigan_v1"
+    command: [ "TTS/server/server.py", "--model_name", "tts_models/en/vctk/vits" ]
+    runtime: nvidia
+    volumes:
+      - ./tts:/root/.local/share
+      - /etc/timezone:/etc/timezone:ro
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - count: all
+              capabilities: [ gpu ]
+
+  qdrant:
+    image: qdrant/qdrant:latest
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    volumes:
+      - ./qdrant_data:/qdrant/storage
+
+  neo4j:
+    image: neo4j:5
+    ports:
+      - "7687:7687"
+      - "7474:7474"
+    environment:
+      - NEO4J_AUTH=neo4j/password
+    volumes:
+      - ./neo4j_data:/data
+
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    volumes:
+      - ./ollama:/root/.ollama

--- a/scripts/start_services.sh
+++ b/scripts/start_services.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Start all services with fresh build
+# Requires Docker and Docker Compose installed
+
+docker compose up -d --build


### PR DESCRIPTION
## Summary
- add docker-compose.yml with services for TTS, Qdrant, Neo4j and Ollama
- ignore local volume directories and Python cache files
- add `.env` for Neo4j credentials
- create start script for launching containers
- document new reminders in AGENTS.md

## Testing
- `docker-compose config`

------
https://chatgpt.com/codex/tasks/task_e_685b172a65d08320be11d4ee11086f49