### PR TITLE
Add ROS 2 container and entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ qdrant_data/
 neo4j_data/
 tts/
 ollama/
+ros2_ws/
 __pycache__/
 *.pyc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,4 +9,5 @@ These instructions apply to the entire repository.
 - Update this file with lessons learned or reminders as the project evolves.
 
 - Ensure local volume directories (qdrant_data, neo4j_data, tts, ollama) exist but remain gitignored.
+- Ensure the ros2_ws workspace directory exists for the ROS container but stays gitignored.
 - Make scripts executable.

--- a/Dockerfile.ros2
+++ b/Dockerfile.ros2
@@ -1,0 +1,23 @@
+FROM osrf/ros:humble-ros-base
+
+# Install Python tools and ROS colcon build system
+RUN apt update && \
+    apt install -y \
+      python3-pip \
+      python3-colcon-common-extensions \
+      python3-rosdep \
+      ros-humble-launch* \
+      git && \
+    rm -rf /var/lib/apt/lists/*
+
+# Setup workspace
+WORKDIR /ros2_ws
+COPY ros2_ws/src ./src
+RUN rosdep update && \
+    rosdep install --from-paths src --ignore-src -r -y && \
+    . /opt/ros/humble/setup.sh && colcon build
+
+# Entrypoint
+COPY scripts/ros_entrypoint.sh /ros2_ws/scripts/ros_entrypoint.sh
+RUN chmod +x /ros2_ws/scripts/ros_entrypoint.sh
+ENTRYPOINT ["/ros2_ws/scripts/ros_entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,3 +45,15 @@ services:
       - "11434:11434"
     volumes:
       - ./ollama:/root/.ollama
+
+  ros2:
+    build:
+      context: .
+      dockerfile: Dockerfile.ros2
+    network_mode: host
+    environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+    volumes:
+      - ./ros2_ws:/ros2_ws
+    devices:
+      - "/dev/ttyUSB0:/dev/ttyUSB0"

--- a/scripts/ros_entrypoint.sh
+++ b/scripts/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+source /opt/ros/humble/setup.bash
+cd /ros2_ws
+source install/setup.bash
+exec "$@"


### PR DESCRIPTION
## Summary
- include Dockerfile for ROS 2 base image and colcon build
- add ros2 container to docker-compose
- ignore ros2_ws workspace dir and update agent instructions
- include entrypoint script for ROS setup

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b18f3ba2c8320a1478fc08720506b