### PR TITLE
Add PETE interface messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Guidelines
+- After modifying ROS interfaces, attempt `colcon build --packages-select psyche_interfaces`.
+- If `colcon` or ROS 2 is unavailable, note the limitation in the PR.
+- Favor thorough inline documentation and add tests when feasible.

--- a/src/psyche_interfaces/CMakeLists.txt
+++ b/src/psyche_interfaces/CMakeLists.txt
@@ -10,13 +10,19 @@ find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(builtin_interfaces REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "action/PlainTextInference.action"
   "action/InferenceWithImages.action"
   "message/StreamedChunk.msg"
-  "message/Sensation.msg"
-  DEPENDENCIES std_msgs sensor_msgs
+  "msg/Sensation.msg"
+  "msg/Impression.msg"
+  "msg/Urge.msg"
+  "msg/Intention.msg"
+  "msg/Feedback.msg"
+  "msg/Completion.msg"
+  DEPENDENCIES std_msgs sensor_msgs builtin_interfaces
 )
 
 if(BUILD_TESTING)

--- a/src/psyche_interfaces/msg/Completion.msg
+++ b/src/psyche_interfaces/msg/Completion.msg
@@ -1,0 +1,3 @@
+psyche_interfaces/msg/Intention intent
+psyche_interfaces/msg/Feedback feedback
+builtin_interfaces/Time stamp

--- a/src/psyche_interfaces/msg/Feedback.msg
+++ b/src/psyche_interfaces/msg/Feedback.msg
@@ -1,0 +1,4 @@
+string source_motor
+string status
+string details
+builtin_interfaces/Time stamp

--- a/src/psyche_interfaces/msg/Impression.msg
+++ b/src/psyche_interfaces/msg/Impression.msg
@@ -1,0 +1,2 @@
+psyche_interfaces/msg/Sensation[] what
+string how

--- a/src/psyche_interfaces/msg/Intention.msg
+++ b/src/psyche_interfaces/msg/Intention.msg
@@ -1,0 +1,4 @@
+string reason
+string target_motor
+string payload_json
+builtin_interfaces/Time stamp

--- a/src/psyche_interfaces/msg/Sensation.msg
+++ b/src/psyche_interfaces/msg/Sensation.msg
@@ -1,0 +1,4 @@
+string kind
+string source
+builtin_interfaces/Time stamp
+string json_payload

--- a/src/psyche_interfaces/msg/Urge.msg
+++ b/src/psyche_interfaces/msg/Urge.msg
@@ -1,0 +1,3 @@
+string reason
+string context
+builtin_interfaces/Time stamp

--- a/src/psyche_interfaces/package.xml
+++ b/src/psyche_interfaces/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
+  <depend>builtin_interfaces</depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 


### PR DESCRIPTION
## Summary
- add messages for PETE core interfaces
- update build files to register new messages
- document agent guidelines

## Testing
- `colcon build --packages-select psyche_interfaces` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1f8fc4748320b9af3aafb2289cc6