### PR TITLE
Add Docker setup guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,5 @@
 - After modifying ROS interfaces, attempt `colcon build --packages-select psyche_interfaces`.
 - If `colcon` or ROS 2 is unavailable, note the limitation in the PR.
 - Favor thorough inline documentation and add tests when feasible.
+- After editing `Dockerfile` or compose files, run `docker compose -f forebrain.yaml build` to ensure images build successfully.
+- Reuse Docker build caches when possible to avoid re-downloading dependencies.

--- a/README.md
+++ b/README.md
@@ -78,3 +78,5 @@ Launching the System
 The system is launched using ROS nodes defined in a launch file, which includes various sensory inputs and processing units to provide a comprehensive and integrated experience on the robot. The configuration ensures that all parts of the robot's system are initiated correctly and communicate effectively, adhering to the established timelines and operational parameters set in the configuration.
 
 By enhancing the documentation in this manner, each aspect of the Psyche project is made clearer, providing a more accessible reference for further development and implementation on various robotic platforms.
+## Docker Setup
+For instructions on building and running the project in Docker, see [docs/docker_setup.md](docs/docker_setup.md).

--- a/docs/docker_setup.md
+++ b/docs/docker_setup.md
@@ -1,0 +1,59 @@
+# Docker Environment Setup
+
+This guide explains how to build and run the Psyche system inside Docker. The repository provides several helper scripts and compose files to streamline the process.
+
+## Prerequisites
+- [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) installed on the host machine.
+- Optional: hardware such as audio devices or GPIO should be made accessible to Docker if required.
+
+## Building the Image
+Run the following command from the project root to build the Docker image using the provided compose configuration:
+
+```bash
+# build all services defined in forebrain.yaml
+docker compose -f forebrain.yaml build
+```
+
+This step caches packages so subsequent builds are faster. If you modify the `Dockerfile` or compose files, rerun the build command.
+
+## Running the Container
+Two helper scripts exist under `launch/` for different hardware setups:
+
+- `launch/forebrain.sh` – launches the main ROS stack alongside additional services like OLLAMA and Neo4j.
+- `launch/motherbrain.sh` – tailored for a single-board computer with attached devices.
+
+Execute the appropriate script to start the containers in detached `screen` sessions:
+
+```bash
+./launch/forebrain.sh
+```
+
+Each script invokes `docker compose` with the matching YAML file so you do not need to run compose manually.
+
+## Accessing the Container
+Once running, attach to the container with:
+
+```bash
+./terminal.sh
+```
+
+This opens an interactive shell inside the `psyche` service.
+
+## Host Setup Script
+For a bare‑metal installation (without Docker) a `setup.sh` script is provided. It installs ROS, Python dependencies, and configures the environment:
+
+```bash
+sudo ./setup.sh
+```
+
+This script is not required for Docker usage but can be helpful for troubleshooting or development directly on the host.
+
+## Stopping Services
+To stop the running containers use standard Docker Compose commands. For example:
+
+```bash
+docker compose -f forebrain.yaml down
+```
+
+The `screen` sessions created by the launch scripts can also be terminated with `screen -ls` and `screen -X -S <name> quit` if needed.
+


### PR DESCRIPTION
## Summary
- document Docker setup and reference helper scripts
- link documentation from README
- add guidelines for Docker builds

## Testing
- `pytest --maxfail=5 -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685b20c913688320a54e89eb5648048d