### PR TITLE
Fix Impression msg type reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,5 @@
 - Reuse Docker build caches when possible to avoid re-downloading dependencies.
 - Document new services (e.g., Qdrant) in the Docker guides and create
   persistent data directories when adding them to compose files.
+- When defining ROS messages, reference types from this package as
+  `psyche_interfaces/MessageType` (without a `/msg` suffix).

--- a/src/psyche_interfaces/msg/Impression.msg
+++ b/src/psyche_interfaces/msg/Impression.msg
@@ -1,2 +1,2 @@
-psyche_interfaces/msg/Sensation[] what
+psyche_interfaces/Sensation[] what
 string how

--- a/src/psyche_interfaces/package.xml
+++ b/src/psyche_interfaces/package.xml
@@ -9,9 +9,13 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <build_depend>rosidl_default_generators</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>builtin_interfaces</depend>
+  <build_depend>builtin_interfaces</build_depend>
+  <exec_depend>builtin_interfaces</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 


### PR DESCRIPTION
## Summary
- reference Sensation type without `/msg`
- declare rosidl dependencies for runtime and builtin interfaces
- clarify AGENTS instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `colcon build --packages-select psyche_interfaces` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b2f8548bc832091440232de4fde51