### PR TITLE
Update AGENTS to clarify ROS tooling absence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # Guidelines
 - After modifying ROS interfaces, attempt `colcon build --packages-select psyche_interfaces`.
 - If `colcon` or ROS 2 is unavailable, note the limitation in the PR.
+- This environment lacks `colcon` and the necessary ROS dependencies, so don't attempt
+  to run ROS commands. Simply document the limitation instead.
 - Favor thorough inline documentation and add tests when feasible.
 - After editing `Dockerfile` or compose files, run `docker compose -f forebrain.yaml build` to ensure images build successfully.
 - Reuse Docker build caches when possible to avoid re-downloading dependencies.


### PR DESCRIPTION
## Summary
- document that this environment doesn't provide `colcon` or ROS dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psyche')*

------
https://chatgpt.com/codex/tasks/task_e_685b30fbff1c8320b72837711241a019