### PR TITLE
Simplify foot service launcher

### DIFF
--- a/provision/services/foot.sh
+++ b/provision/services/foot.sh
@@ -25,102 +25,30 @@ RULE
   # launcher for systemd with resilient retry loop
   common_install_launcher foot LAUNCH <<'LAUNCH'
 #!/usr/bin/env bash
-set -e
-LOG=/tmp/create_driver.log
-PORT_DEFAULT=/dev/create
-PORT="${CREATE_PORT:-$PORT_DEFAULT}"
+set -euo pipefail
 
-# Diagnostics / tuning env vars (may be exported via /etc/default/psyched-foot)
-FAIL_MAX_BEFORE_BACKOFF="${FAIL_MAX_BEFORE_BACKOFF:-20}"   # after this many rapid fails, add longer sleep
-BACKOFF_SLEEP="${BACKOFF_SLEEP:-10}"
-FOOT_DEBUG="${FOOT_DEBUG:-0}"              # 1 for verbose
-FOOT_DIAG_INTERVAL="${FOOT_DIAG_INTERVAL:-30}" # seconds between deep diagnostics
-LAST_DIAG_TS=0
-FAIL_COUNT=0
-
-# Helper: timestamped log line
-log() { echo "[foot $(date +%H:%M:%S)] $*" | tee -a "$LOG"; }
-
-# Helper: run deep diagnostics (serial, permissions, udev, dmesg excerpt)
-deep_diagnostics() {
-  log "--- Deep diagnostics start ---"
-  if [ -L "$PORT" ]; then ls -l "$PORT" | tee -a "$LOG" || true; fi
-  if [ -e "$PORT" ]; then
-    stat "$PORT" 2>&1 | tee -a "$LOG" || true
-    sudo udevadm info --query=all --name="$PORT" 2>&1 | tee -a "$LOG" || true
-  else
-    log "Device $PORT does not exist (symlink or node missing)"
-  fi
-  # Enumerate candidate USB serial devices
-  ls -l /dev/ttyUSB* 2>/dev/null | head -n 20 | tee -a "$LOG" || true
-  # Recent dmesg lines related to USB / tty
-  dmesg | egrep -i 'ttyUSB|ftdi|pl2303|usb' | tail -n 25 | tee -a "$LOG" || true
-  log "ROS_DISTRO=${ROS_DISTRO:-unset}; create_driver presence check:"
-  if command -v ros2 >/dev/null 2>&1; then
-    ros2 pkg executables create_driver 2>&1 | tee -a "$LOG" || true
-    ros2 pkg list | egrep -i 'create|libcreate' 2>/dev/null | tee -a "$LOG" || true
-  else
-    log "ros2 command not found in PATH"
-  fi
-  log "--- Deep diagnostics end ---"
-}
-
-# Optional overrides via /etc/default/psyched-foot
-if [ -f /etc/default/psyched-foot ]; then
-  . /etc/default/psyched-foot
-  PORT="${CREATE_PORT:-$PORT}"
-fi
-
-# Source ROS and workspace overlays if present (guard nounset)
+# Source ROS 2 underlay and the psyched overlay when available. We relax nounset
+# around the sourcing steps because the setup files rely on expected shell
+# variables that may be undefined otherwise.
 set +u; [ -f "/opt/ros/${ROS_DISTRO:-jazzy}/setup.bash" ] && source "/opt/ros/${ROS_DISTRO:-jazzy}/setup.bash"; set -u
 set +u; [ -f /opt/psyched/ws/install/setup.bash ] && source /opt/psyched/ws/install/setup.bash; set -u
 
-log "launcher started. Using port=$PORT"
-log "FOOT_DEBUG=$FOOT_DEBUG FAIL_MAX_BEFORE_BACKOFF=$FAIL_MAX_BEFORE_BACKOFF BACKOFF_SLEEP=$BACKOFF_SLEEP"
+# Allow operators to override the launch entrypoint if necessary while keeping
+# the default behavior aligned with manual bringup instructions.
+CREATE_LAUNCH_PACKAGE="${CREATE_LAUNCH_PACKAGE:-create_bringup}"
+CREATE_LAUNCH_FILE="${CREATE_LAUNCH_FILE:-create_1.launch}"
+CREATE_LAUNCH_ARGS="${CREATE_LAUNCH_ARGS:-}"
 
-udev_settled=0
-waiting_logged=0
-while true; do
-  # Wait for device symlink to appear
-  if [ ! -e "$PORT" ]; then
-    if [ "$udev_settled" -eq 0 ]; then
-      if command -v udevadm >/dev/null 2>&1; then
-        sudo udevadm settle || true
-      fi
-      udev_settled=1
-    fi
-    if [ "$waiting_logged" -eq 0 ]; then
-      log "Waiting for $PORT ..."
-      waiting_logged=1
-      deep_diagnostics || true
-    fi
-    sleep 2
-    continue
-  fi
+read -r -a extra_launch_args <<<"${CREATE_LAUNCH_ARGS}"
+if [ ${#extra_launch_args[@]} -eq 1 ] && [ -z "${extra_launch_args[0]}" ]; then
+  extra_launch_args=()
+fi
 
-  udev_settled=0
-  waiting_logged=0
-  log "Starting create_driver on $PORT (fail_count=$FAIL_COUNT)"
-  set +e
-  ros2 run create_driver create_driver_node --ros-args -p port:="$PORT" -r /odom:=/odom >> "$LOG" 2>&1
-  RC=$?
-  set -e
-  FAIL_COUNT=$((FAIL_COUNT+1))
-  log "create_driver exited rc=$RC (fail_count=$FAIL_COUNT)"
-  NOW=$(date +%s)
-  # Periodic deep diagnostics
-  if [ $((NOW - LAST_DIAG_TS)) -ge "$FOOT_DIAG_INTERVAL" ]; then
-    LAST_DIAG_TS=$NOW
-    deep_diagnostics || true
-  fi
-  # If many rapid failures, introduce backoff
-  if [ "$FAIL_COUNT" -ge "$FAIL_MAX_BEFORE_BACKOFF" ]; then
-    log "Failure count >= $FAIL_MAX_BEFORE_BACKOFF applying backoff sleep $BACKOFF_SLEEP"
-    sleep "$BACKOFF_SLEEP"
-  else
-    sleep 3
-  fi
-done
+if [ "${FOOT_DEBUG:-0}" != "0" ]; then
+  echo "[foot] exec ros2 launch ${CREATE_LAUNCH_PACKAGE} ${CREATE_LAUNCH_FILE} ${extra_launch_args[*]}" >&2
+fi
+
+exec ros2 launch "${CREATE_LAUNCH_PACKAGE}" "${CREATE_LAUNCH_FILE}" "${extra_launch_args[@]}"
 LAUNCH
 }
 

--- a/tests/services/test_foot_launcher.py
+++ b/tests/services/test_foot_launcher.py
@@ -1,0 +1,37 @@
+"""Behavioral tests for the foot service launcher.
+
+These tests act as a safety net to ensure the foot service keeps invoking the
+expected ros2 launch command. We intentionally phrase the assertions using a
+Given/When/Then structure to keep the desired behavior explicit.
+"""
+
+from pathlib import Path
+
+
+def _read_launcher_snippet() -> str:
+    """Return the foot launcher installation snippet as plain text."""
+
+    # Given the repository root (two directories up from this test module)
+    repo_root = Path(__file__).resolve().parents[2]
+
+    # When we load the provision script for the foot service
+    script_path = repo_root / "provision" / "services" / "foot.sh"
+    script_text = script_path.read_text(encoding="utf-8")
+
+    # Then we focus on the launcher section that systemd executes
+    start_token = "common_install_launcher foot"
+    start_index = script_text.index(start_token)
+    return script_text[start_index:]
+
+
+def test_launcher_executes_create_bringup() -> None:
+    """The foot launcher should invoke the expected ros2 launch entrypoint."""
+
+    snippet = _read_launcher_snippet()
+
+    # Given the launcher snippet captured from the provision script
+    # When we look for the ros2 launch invocation
+    # Then it should launch the create_bringup create_1 launch file by default
+    assert "exec ros2 launch" in snippet
+    assert 'CREATE_LAUNCH_PACKAGE="${CREATE_LAUNCH_PACKAGE:-create_bringup}"' in snippet
+    assert 'CREATE_LAUNCH_FILE="${CREATE_LAUNCH_FILE:-create_1.launch}"' in snippet


### PR DESCRIPTION
## Summary
- simplify the foot systemd launcher to exec `ros2 launch create_bringup create_1.launch` with optional overrides
- add a regression test that guards the default foot launch behavior

## Testing
- python -m pytest tests/services/test_foot_launcher.py

------
https://chatgpt.com/codex/tasks/task_e_68cb243225488320adda1b2ac26e1693