### PR TITLE
Fix voice playback by exporting XDG runtime dir

### DIFF
--- a/provision/systemd/install_units.sh
+++ b/provision/systemd/install_units.sh
@@ -24,7 +24,10 @@ Environment=RCUTILS_LOGGING_DIR=/var/log/ros
 # Avoid setup scripts tripping on unbound COLCON_TRACE under nounset
 Environment=AMENT_TRACE_SETUP_FILES=0
 Environment=COLCON_TRACE=
+Environment=XDG_RUNTIME_DIR=/run/user/%U
 # Prepare log directories before start
+ExecStartPre=/bin/mkdir -p /run/user/%U
+ExecStartPre=/bin/chmod 700 /run/user/%U
 ExecStartPre=/bin/mkdir -p /var/log/ros
 ExecStartPre=/bin/chmod 755 /var/log/ros
 ExecStartPre=/bin/mkdir -p /root/.ros

--- a/tests/test_systemd_template.py
+++ b/tests/test_systemd_template.py
@@ -1,0 +1,9 @@
+import pathlib
+
+
+def test_psyched_service_template_sets_runtime_dir():
+    template = pathlib.Path("provision/systemd/install_units.sh").read_text()
+    assert "Environment=XDG_RUNTIME_DIR=/run/user/%U" in template
+    assert "ExecStartPre=/bin/mkdir -p /run/user/%U" in template
+    assert "ExecStartPre=/bin/chmod 700 /run/user/%U" in template
+


### PR DESCRIPTION
## Summary
- export XDG_RUNTIME_DIR from the psyched@.service template and ensure the runtime directory exists before start-up
- add a pytest regression test to pin the systemd template changes

## Testing
- python3 -m pytest tests/test_systemd_template.py

------
https://chatgpt.com/codex/tasks/task_e_68cb25306ff88320a4873f80b5dd3456