### PR TITLE
Add bearing helper command to CLI

### DIFF
--- a/cli/psy
+++ b/cli/psy
@@ -79,6 +79,7 @@ Usage:
 
 Helper:
   psh say <text>               Convenience wrapper to publish to /voice/$(hostname -s)
+  psh bearing <deg>            Publish /cmd_vel Twist to rotate toward the bearing
 USAGE
 }
 
@@ -257,6 +258,204 @@ case "$cmd" in
         ;;
       *) usage; exit 1;;
     esac
+    ;;
+  bearing)
+    # Publish a geometry_msgs/msg/Twist command that mirrors the proportional
+    # turning logic in psyche_vision/object_controller.py.
+    gain="${PSH_BEARING_GAIN:-2.0}"
+    max_ang="${PSH_BEARING_MAX_ANGULAR:-0.5}"
+    tolerance="${PSH_BEARING_TOLERANCE:-2.0}"
+    topic="${PSH_BEARING_TOPIC:-/cmd_vel}"
+    dry_run=0
+    bearing_arg=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -g|--gain)
+          [ $# -ge 2 ] || { echo "[psy][bearing] ERROR: --gain requires a value" >&2; exit 1; }
+          gain="$2"
+          shift 2
+          ;;
+        -m|--max)
+          [ $# -ge 2 ] || { echo "[psy][bearing] ERROR: --max requires a value" >&2; exit 1; }
+          max_ang="$2"
+          shift 2
+          ;;
+        -t|--tolerance)
+          [ $# -ge 2 ] || { echo "[psy][bearing] ERROR: --tolerance requires a value" >&2; exit 1; }
+          tolerance="$2"
+          shift 2
+          ;;
+        --topic)
+          [ $# -ge 2 ] || { echo "[psy][bearing] ERROR: --topic requires a name" >&2; exit 1; }
+          topic="$2"
+          shift 2
+          ;;
+        --dry-run)
+          dry_run=1
+          shift
+          ;;
+        -h|--help)
+          cat <<'HELP'
+Usage: psy bearing [options] <bearing_degrees>
+
+Options:
+  -g, --gain <float>         Override proportional gain (default PSH_BEARING_GAIN or 2.0)
+  -m, --max <float>          Override max angular velocity in rad/s (default PSH_BEARING_MAX_ANGULAR or 0.5)
+  -t, --tolerance <float>    Override deadzone tolerance in degrees (default PSH_BEARING_TOLERANCE or 2.0)
+      --topic <name>         Publish to a different Twist topic (default PSH_BEARING_TOPIC or /cmd_vel)
+      --dry-run              Print the computed command without invoking ros2
+HELP
+          exit 0
+          ;;
+        --)
+          shift
+          while [ $# -gt 0 ]; do
+            if [ -n "$bearing_arg" ]; then
+              echo "[psy][bearing] ERROR: multiple bearing values provided ($bearing_arg, $1)" >&2
+              exit 1
+            fi
+            bearing_arg="$1"
+            shift
+          done
+          ;;
+        -* )
+          if [ -z "$bearing_arg" ] && [[ "$1" =~ ^-?[0-9]+([.][0-9]+)?$ ]]; then
+            bearing_arg="$1"
+            shift
+          else
+            echo "[psy][bearing] ERROR: unknown option $1" >&2
+            exit 1
+          fi
+          ;;
+        *)
+          if [ -n "$bearing_arg" ]; then
+            echo "[psy][bearing] ERROR: multiple bearing values provided ($bearing_arg, $1)" >&2
+            exit 1
+          fi
+          bearing_arg="$1"
+          shift
+          ;;
+      esac
+    done
+    if [ -z "$bearing_arg" ]; then
+      echo "[psy][bearing] ERROR: bearing degrees argument is required." >&2
+      exit 1
+    fi
+
+    if ! calc_output="$(python3 - "$bearing_arg" "$gain" "$max_ang" "$tolerance" <<'PY'
+import math
+import sys
+
+PREFIX = "[psy][bearing]"
+
+def fail(message: str) -> None:
+    print(f"{PREFIX} ERROR: {message}", file=sys.stderr)
+    sys.exit(2)
+
+if len(sys.argv) < 5:
+    fail("internal argument parsing error (missing computation parameters).")
+
+try:
+    bearing = float(sys.argv[1])
+except ValueError:
+    fail("bearing must be a valid number of degrees.")
+except IndexError:
+    fail("bearing argument missing.")
+
+try:
+    gain = float(sys.argv[2])
+    max_ang = float(sys.argv[3])
+    tolerance = float(sys.argv[4])
+except ValueError:
+    fail("gain, max angular velocity, and tolerance must be numeric.")
+
+if math.isnan(bearing) or math.isinf(bearing):
+    fail("bearing must be finite.")
+
+for label, value, allow_zero in (
+    ("proportional gain", gain, False),
+    ("max angular velocity", max_ang, False),
+    ("angle tolerance", tolerance, True),
+):
+    if math.isnan(value) or math.isinf(value):
+        fail(f"{label} must be finite.")
+    if allow_zero:
+        if value < 0.0:
+            fail(f"{label} must be greater than or equal to zero.")
+    else:
+        if value <= 0.0:
+            fail(f"{label} must be greater than zero.")
+
+within_tol = abs(bearing) < tolerance
+raw = 0.0
+clamped = False
+if within_tol:
+    value = 0.0
+else:
+    raw = gain * math.radians(bearing)
+    value = raw
+    if value > max_ang:
+        value = max_ang
+        clamped = True
+    elif value < -max_ang:
+        value = -max_ang
+        clamped = True
+
+if abs(value) < 1e-9:
+    value = 0.0
+
+print(f"{value:.6f}")
+print(f"{bearing:.6f}")
+print("1" if within_tol else "0")
+print("1" if clamped else "0")
+print(f"{raw:.6f}")
+PY
+)"; then
+      status=$?
+      exit $status
+    fi
+
+    mapfile -t _calc <<< "$calc_output"
+    angular="${_calc[0]:-0}"
+    bearing_fmt="${_calc[1]:-0}"
+    within_tol="${_calc[2]:-0}"
+    clamped="${_calc[3]:-0}"
+
+    printf -v bearing_disp "%.2f" "$bearing_fmt"
+    printf -v angular_disp "%.6f" "$angular"
+    printf -v tol_disp "%.2f" "$tolerance"
+    printf -v gain_disp "%.2f" "$gain"
+    printf -v max_disp "%.2f" "$max_ang"
+
+    if [ "$within_tol" = "1" ]; then
+      echo "[psy][bearing] bearing=${bearing_disp}° within tolerance ${tol_disp}° — publishing stop command to ${topic} (angular.z=${angular_disp})"
+    else
+      if [ "$clamped" = "1" ]; then
+        echo "[psy][bearing] bearing=${bearing_disp}° -> angular.z=${angular_disp} rad/s (clamped to ±${max_disp} rad/s; gain=${gain_disp}) on ${topic}"
+      else
+        echo "[psy][bearing] bearing=${bearing_disp}° -> angular.z=${angular_disp} rad/s (gain=${gain_disp}, max=${max_disp}) on ${topic}"
+      fi
+    fi
+
+    printf -v twist_msg "{linear: {x: 0.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: %s}}" "$angular_disp"
+
+    if [ "$dry_run" = "1" ]; then
+      echo "[psy][bearing] Dry run requested; not publishing to ${topic}"
+      exit 0
+    fi
+
+    if ! command -v ros2 >/dev/null 2>&1; then
+      set +u; source /opt/ros/${ROS_DISTRO:-jazzy}/setup.bash 2>/dev/null || true; set -u
+    fi
+    if ! command -v ros2 >/dev/null 2>&1; then
+      echo "[psy][bearing] ERROR: ros2 CLI not found (install or source environment)." >&2
+      exit 2
+    fi
+
+    ros2 topic pub --once "$topic" geometry_msgs/msg/Twist "$twist_msg" || {
+      echo "[psy][bearing] ERROR: failed to publish Twist message on ${topic}" >&2
+      exit 3
+    }
     ;;
   say)
     # Publish a message to voice topic

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -58,6 +58,20 @@ credentials when prompted.
   `ros2 topic pub --once` CLI. The command auto-sources `/opt/ros/<distro>/setup.bash`
   if the ROS environment is not already in the shell.
 
+## `psy bearing <degrees>`
+- Computes the proportional angular velocity that the vision controller would use
+  for the supplied bearing and publishes a single `geometry_msgs/msg/Twist` on
+  `/cmd_vel` (configurable via `--topic`).
+- Mirrors the defaults from `psyche_vision/object_controller.py`:
+  gain of `2.0`, maximum angular velocity of `0.5` rad/s, and a ±`2°` deadzone.
+- Options allow quick experimentation: `--gain`, `--max`, `--tolerance`,
+  `--topic`, and `--dry-run` (print without publishing).
+- Environment variables provide persistent overrides:
+  `PSH_BEARING_GAIN`, `PSH_BEARING_MAX_ANGULAR`, `PSH_BEARING_TOLERANCE`, and
+  `PSH_BEARING_TOPIC`.
+- Example: `psh bearing 15` prints the computed command and publishes the
+  matching Twist to `/cmd_vel` so the base rotates right.
+
 ## Helper Scripts
 
 Two helper utilities ship alongside the CLI:

--- a/tests/test_psh_bearing.py
+++ b/tests/test_psh_bearing.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Behavioral tests for the ``psh bearing`` command.
+
+These tests exercise the CLI end-to-end by stubbing out the ``ros2`` executable
+so we can observe the command that would have been published to ``/cmd_vel``.
+The tests intentionally avoid depending on ROS 2 or the real workspace so that
+they can run quickly in CI and local development environments.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class BearingCommandTest(unittest.TestCase):
+    """End-to-end coverage of the ``psh bearing`` helper."""
+
+    def _run_bearing(self, bearing: float, *extra_args: str):
+        """Invoke ``psh bearing`` with a stub ``ros2`` executable."""
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            ros2_log = tmp_path / "ros2.log"
+            ros2_stub = tmp_path / "ros2"
+            ros2_stub.write_text(
+                f"""#!/usr/bin/env bash
+set -e
+# Log each argument on its own line for easy assertions.
+{{ printf '%s\\n' "$@"; }} >> "{ros2_log}"
+"""
+            )
+            ros2_stub.chmod(0o755)
+
+            env = os.environ.copy()
+            env["PATH"] = f"{tmp_path}:{env.get('PATH', '')}"
+
+            cmd = [
+                "bash",
+                str(REPO_ROOT / "cli" / "psy"),
+                "bearing",
+            ]
+            if extra_args:
+                cmd.extend(extra_args)
+            cmd.append(str(bearing))
+
+            completed = subprocess.run(
+                cmd,
+                cwd=REPO_ROOT,
+                env=env,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            log_contents = ros2_log.read_text().strip().splitlines()
+
+        return completed, log_contents
+
+    def test_bearing_generates_expected_twist(self):
+        """A moderate bearing should result in a proportional angular velocity."""
+
+        result, lines = self._run_bearing(10.0)
+
+        self.assertEqual(lines[:3], ["topic", "pub", "--once"])
+        self.assertEqual(lines[3], "/cmd_vel")
+        self.assertEqual(lines[4], "geometry_msgs/msg/Twist")
+        self.assertEqual(len(lines), 6)
+
+        twist = lines[5]
+        self.assertIn("linear: {x: 0.0, y: 0.0, z: 0.0}", twist)
+        match = re.search(r"angular: \{x: 0\.0, y: 0\.0, z: ([^}]+)\}", twist)
+        self.assertIsNotNone(match, f"Failed to parse angular velocity from: {twist}")
+        angular_z = float(match.group(1))
+
+        expected = 2.0 * math.radians(10.0)
+        self.assertTrue(
+            math.isclose(angular_z, expected, rel_tol=1e-6, abs_tol=1e-6),
+            f"Expected angular velocity {expected}, got {angular_z}",
+        )
+
+        self.assertIn("angular.z=0.349066", result.stdout)
+        self.assertIn("bearing=10.00°", result.stdout)
+
+    def test_bearing_honours_deadzone(self):
+        """Small bearings inside the tolerance should command a stop."""
+
+        result, lines = self._run_bearing(1.0)
+        twist = lines[5]
+        match = re.search(r"angular: \{x: 0\.0, y: 0\.0, z: ([^}]+)\}", twist)
+        self.assertIsNotNone(match, f"Failed to parse angular velocity from: {twist}")
+        angular_z = float(match.group(1))
+        self.assertTrue(math.isclose(angular_z, 0.0, abs_tol=1e-9))
+
+        self.assertIn("within tolerance", result.stdout.lower())
+        self.assertIn("angular.z=0.000000", result.stdout)
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience for direct execution
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a `psy bearing` helper that computes and publishes a `/cmd_vel` Twist for a requested bearing using the same proportional controller defaults as the vision stack
- document the new CLI helper and its tuning options in the CLI reference
- cover the command with end-to-end tests that stub `ros2` to verify the published message contents

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68cb25eb05ec83209781915d5d13cef6