### PR TITLE
Ensure eye_kinect publishes point cloud

### DIFF
--- a/provision/services/eye_kinect.sh
+++ b/provision/services/eye_kinect.sh
@@ -267,12 +267,7 @@ echo "[psy][eye_kinect] Launching Kinect node at $(date)"
 set +u; source /opt/ros/${ROS_DISTRO:-jazzy}/setup.bash; set -u
 root="${PSY_ROOT:-/opt/psyched}"
 set +u; [ -f "${root}/ws/install/setup.bash" ] && source "${root}/ws/install/setup.bash"; set -u
-exec ros2 run kinect_ros2 kinect_ros2_node --ros-args \
-  -r image_raw:=/camera/image_raw \
-  -r camera_info:=/camera/camera_info \
-  -r depth/image_raw:=/camera/depth/image_raw \
-  -r depth/camera_info:=/camera/depth/camera_info \
-  -r points:=/camera/depth/points
+exec ros2 launch psyche_vision eye_kinect.launch.py
 LAUNCH
 }
 

--- a/tests/services/test_eye_kinect.py
+++ b/tests/services/test_eye_kinect.py
@@ -1,0 +1,58 @@
+"""Behavioral tests for the eye_kinect provisioning service.
+
+We follow a Given/When/Then narrative to assert that the Kinect v1 driver
+publishes everything downstream nodes need to build a point cloud.
+"""
+
+from pathlib import Path
+
+
+def _load_eye_kinect_service_script() -> str:
+    """Return the eye_kinect provision script as text."""
+
+    # Given the repository root (two directories up from this test module)
+    repo_root = Path(__file__).resolve().parents[2]
+
+    # When we read the eye_kinect provisioning script
+    script_path = repo_root / "provision" / "services" / "eye_kinect.sh"
+    return script_path.read_text(encoding="utf-8")
+
+
+def test_eye_kinect_provisions_depth_image_proc() -> None:
+    """The service should queue depth_image_proc so the point cloud node is available."""
+
+    script_text = _load_eye_kinect_service_script()
+
+    # Given the provisioning script text
+    # When we scan the queued apt packages
+    # Then the depth_image_proc package should be present
+    assert "ros-${ROS_DISTRO:-jazzy}-depth-image-proc" in script_text
+
+
+def test_eye_kinect_launcher_uses_psyche_launch_file() -> None:
+    """The launcher should delegate to a psyche_vision launch file."""
+
+    script_text = _load_eye_kinect_service_script()
+
+    # Given the provisioning script text
+    # When we inspect the launcher command
+    # Then we should see ros2 launch pointing at psyche_vision's eye_kinect launch file
+    assert "ros2 launch psyche_vision eye_kinect.launch.py" in script_text
+
+
+def test_eye_kinect_launch_spawns_point_cloud_process() -> None:
+    """The launch file should run the depth_image_proc point cloud executable."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    launch_file = repo_root / "ws" / "src" / "psyche_vision" / "launch" / "eye_kinect.launch.py"
+
+    # Given the launch file text
+    text = launch_file.read_text(encoding="utf-8")
+
+    # When we look for the point cloud node configuration
+    # Then we should find the depth_image_proc executable and Kinect remappings
+    assert 'package="depth_image_proc"' in text
+    assert 'executable="point_cloud_xyzrgb"' in text
+    assert "rgb/image_rect_color" in text
+    assert "depth/image_rect" in text
+    assert '("points", "/camera/depth/points")' in text

--- a/ws/src/psyche_vision/launch/eye_kinect.launch.py
+++ b/ws/src/psyche_vision/launch/eye_kinect.launch.py
@@ -1,0 +1,44 @@
+"""Launch the Kinect v1 driver alongside a depth-to-point-cloud pipeline.
+
+This launch description remaps the topics produced by the libfreenect-based
+`kinect_ros2` component into the shared `/camera` namespace and starts the
+`depth_image_proc` point-cloud node so downstream consumers receive organized
+XYZRGB data. The setup assumes the original Kinect (v1) sensor and libfreenect.
+"""
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description() -> LaunchDescription:
+    """Create a launch description for the eye_kinect service."""
+
+    kinect_driver = Node(
+        package="kinect_ros2",
+        executable="kinect_ros2_node",
+        name="eye_kinect_driver",
+        output="screen",
+        remappings=[
+            ("image_raw", "/camera/image_raw"),
+            ("camera_info", "/camera/camera_info"),
+            ("depth/image_raw", "/camera/depth/image_raw"),
+            ("depth/camera_info", "/camera/depth/camera_info"),
+        ],
+    )
+
+    point_cloud = Node(
+        package="depth_image_proc",
+        executable="point_cloud_xyzrgb",
+        name="eye_kinect_point_cloud",
+        output="screen",
+        parameters=[{"approximate_sync": True}],
+        remappings=[
+            ("rgb/image_rect_color", "/camera/image_raw"),
+            ("rgb/camera_info", "/camera/camera_info"),
+            ("depth/image_rect", "/camera/depth/image_raw"),
+            ("depth/camera_info", "/camera/depth/camera_info"),
+            ("points", "/camera/depth/points"),
+        ],
+    )
+
+    return LaunchDescription([kinect_driver, point_cloud])

--- a/ws/src/psyche_vision/setup.py
+++ b/ws/src/psyche_vision/setup.py
@@ -10,7 +10,11 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
-    ('share/' + package_name + '/launch', ['launch/vision_launch.py', 'launch/face_object.launch.py']),
+        ('share/' + package_name + '/launch', [
+            'launch/vision_launch.py',
+            'launch/face_object.launch.py',
+            'launch/eye_kinect.launch.py',
+        ]),
     ],
     install_requires=['setuptools'],
     zip_safe=True,


### PR DESCRIPTION
## Summary
- add a launch file that pairs the Kinect v1 driver with depth_image_proc to publish `/camera/depth/points`
- switch the eye_kinect systemd launcher to use the new launch description and install it with the psyche_vision package
- cover the provisioning script with behavior-driven tests that confirm the point cloud pipeline wiring

## Testing
- pytest tests/services/test_eye_kinect.py

------
https://chatgpt.com/codex/tasks/task_e_68cbccd67f5883209d0fd0e198b59e37