### PR TITLE
Add streaming audio and transcript interfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,6 @@
 - When a provisioning service needs Docker, call `common_ensure_docker_runtime`
   from `provision/services/_common.sh` instead of duplicating package installs.
   The helper takes care of the official repository, keyring, and package queueing.
+- Full `pytest` runs pull in `src/psyche_vision/test_vision.py`, which imports
+  `numpy`. Install it (`pip install numpy`) before executing the entire suite or
+  target narrower tests when the dependency is unavailable.

--- a/src/psyche_interfaces/CMakeLists.txt
+++ b/src/psyche_interfaces/CMakeLists.txt
@@ -6,7 +6,14 @@ find_package(rosidl_default_generators REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 
 set(msg_files
+  "msg/AudioPCM.msg"
+  "msg/AudioChunk.msg"
+  "msg/AudioSegment.msg"
   "msg/Conversation.msg"
+  "msg/TranscriptEvent.msg"
+  "msg/TranscriptPartial.msg"
+  "msg/TranscriptSegment.msg"
+  "msg/TranscriptWhole.msg"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/src/psyche_interfaces/msg/AudioChunk.msg
+++ b/src/psyche_interfaces/msg/AudioChunk.msg
@@ -1,0 +1,11 @@
+# Rolling utterance buffer published by ``segmenter`` on /audio/segment/current.
+# ``sequence`` increments per publish so downstream ASR nodes can detect missed
+# updates. ``wav_data`` carries a self-contained little-endian WAV clip encoded
+# with the advertised sample rate and channel count.
+builtin_interfaces/Time stamp_start  # first sample timestamp
+builtin_interfaces/Time stamp_end    # end timestamp for the chunk window
+string segment_id                    # stable identifier for the active segment
+uint32 sequence                      # monotonically increasing chunk counter
+uint32 sample_rate                   # samples per second of the clip
+uint8  channels                      # channel count within the WAV payload
+uint8[] wav_data                     # PCM WAV data for the chunk window

--- a/src/psyche_interfaces/msg/AudioPCM.msg
+++ b/src/psyche_interfaces/msg/AudioPCM.msg
@@ -1,0 +1,11 @@
+# Raw audio frame captured by ``ear_pcm`` and published on /audio/pcm.
+#
+# Consumers can reconstruct the absolute position using ``frame_index`` and the
+# ``sample_rate``/``channels`` metadata. ``sample_format`` follows the standard
+# ROS audio conventions: 1 = signed 16-bit PCM, 3 = 32-bit float PCM.
+builtin_interfaces/Time stamp        # wall-clock time of capture
+uint32 sample_rate                   # samples per second (e.g., 16000)
+uint8  channels                      # number of interleaved channels
+uint8  sample_format                 # encoded sample format identifier
+uint32 frame_index                   # monotonically increasing frame counter
+uint8[] data                         # interleaved PCM frame payload

--- a/src/psyche_interfaces/msg/AudioSegment.msg
+++ b/src/psyche_interfaces/msg/AudioSegment.msg
@@ -1,0 +1,11 @@
+# Finalised utterance published by ``segmenter`` on /audio/segment/final.
+# ``cut_by_timeout`` indicates the segment was truncated because
+# ``max_segment_ms`` elapsed; this allows ASR nodes to optionally stitch
+# ``/audio/segment/final/chunks3s`` sub-clips before decoding.
+builtin_interfaces/Time stamp_start  # start time for the full segment
+builtin_interfaces/Time stamp_end    # end time of the last sample
+string segment_id                    # unique identifier for the closed segment
+uint32 sample_rate                   # samples per second for the payload
+uint8  channels                      # channel count of the WAV data
+uint8[] wav_data                     # PCM WAV data for the final segment
+bool cut_by_timeout                  # true when the segment hit the timeout guard

--- a/src/psyche_interfaces/msg/TranscriptEvent.msg
+++ b/src/psyche_interfaces/msg/TranscriptEvent.msg
@@ -1,0 +1,9 @@
+# Unified UI event stream combining partial, final, and HQ transcript updates.
+# ``payload_json`` is deliberately small and versioned by the downstream server;
+# it typically carries ``segment_id`` and text fields encoded as UTF-8 JSON.
+uint8 KIND_PARTIAL=0                  # live partial hypothesis update
+uint8 KIND_FINAL=1                    # finalised segment ready for display
+uint8 KIND_HQ_PATCH=2                 # high-quality diff applied to stable text
+builtin_interfaces/Time stamp_emitted # timestamp at emission
+uint8 kind                            # one of the KIND_* constants
+string payload_json                   # small JSON payload describing the update

--- a/src/psyche_interfaces/msg/TranscriptPartial.msg
+++ b/src/psyche_interfaces/msg/TranscriptPartial.msg
@@ -1,0 +1,9 @@
+# Low-latency hypothesis for the currently open audio segment.
+# ``rev`` should increment for each update so ``transcript_fuser`` can discard
+# superseded revisions. ``confidence`` expresses a lightweight heuristic for UI
+# display; downstream components may ignore it.
+string segment_id                    # identifier that matches the audio segment
+uint32 rev                           # monotonically increasing revision number
+builtin_interfaces/Time stamp_emitted # emission time of this partial hypothesis
+string text                          # raw UTF-8 transcription
+float32 confidence                   # optional confidence (0.0-1.0)

--- a/src/psyche_interfaces/msg/TranscriptSegment.msg
+++ b/src/psyche_interfaces/msg/TranscriptSegment.msg
@@ -1,0 +1,9 @@
+# Stable transcription for a completed audio segment.
+# ``segment_start``/``segment_end`` reflect the timestamps emitted with the
+# corresponding ``AudioSegment`` message so timeline visualisations can align
+# text and waveform samples.
+string segment_id                     # identifier for the audio segment
+builtin_interfaces/Time segment_start # first sample time in the segment
+builtin_interfaces/Time segment_end   # final sample time in the segment
+string text                           # final transcript text
+float32 confidence                    # decoder confidence for the full segment

--- a/src/psyche_interfaces/msg/TranscriptWhole.msg
+++ b/src/psyche_interfaces/msg/TranscriptWhole.msg
@@ -1,0 +1,7 @@
+# High-quality diff emitted by ``asr_hq`` with replacements applied to the
+# canonical transcript buffer. Each index pair defines the half-open character
+# range ``[start_char[i], end_char[i])`` to be substituted with ``text[i]``.
+builtin_interfaces/Time stamp_emitted # when the refinement was produced
+uint32[] start_char                   # inclusive starting offsets in the document
+uint32[] end_char                     # exclusive end offsets for each replacement
+string[] text                         # replacement strings in UTF-8

--- a/tests/test_audio_interface_msgs.py
+++ b/tests/test_audio_interface_msgs.py
@@ -1,0 +1,151 @@
+"""Behavior specs for the audio/transcript interface message definitions.
+
+These tests codify the agreed field layout for the streaming ASR stack so we
+can iterate on the message descriptions using TDD. Each message file is parsed
+as a flat list of ``type name`` declarations and constants; the expectations are
+kept deliberately small so they act as living documentation instead of brittle
+fixture dumps.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MSG_DIR = REPO_ROOT / "src" / "psyche_interfaces" / "msg"
+
+
+def _parse_msg_fields(msg_path: Path) -> Tuple[List[Tuple[str, str]], Dict[str, Tuple[str, str]]]:
+    """Return (fields, constants) for the ``.msg`` definition.
+
+    Comments and blank lines are ignored. Field order is preserved to ensure the
+    definition matches our documentation verbatim, making it easy to spot
+    regressions in future diffs.
+    """
+
+    fields: List[Tuple[str, str]] = []
+    constants: Dict[str, Tuple[str, str]] = {}
+    for raw_line in msg_path.read_text().splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if "=" in line:
+            lhs, rhs = line.split("=", 1)
+            rhs = rhs.strip()
+            lhs = lhs.strip()
+            if " " not in lhs:
+                pytest.fail(f"Malformed constant declaration '{raw_line}' in {msg_path.name}")
+            constant_type, constant_name = lhs.split(" ", 1)
+            constants[constant_name.strip()] = (constant_type.strip(), rhs)
+            continue
+        if " " not in line:
+            pytest.fail(f"Expected '<type> <name>' line in {msg_path.name}: '{raw_line}'")
+        field_type, field_name = line.rsplit(" ", 1)
+        fields.append((field_type.strip(), field_name.strip()))
+    return fields, constants
+
+
+def _assert_msg_signature(msg_name: str, expected_fields: List[Tuple[str, str]], expected_constants=None) -> None:
+    msg_path = MSG_DIR / msg_name
+    assert msg_path.exists(), f"Expected {msg_name} to exist in {MSG_DIR}"
+    fields, constants = _parse_msg_fields(msg_path)
+    assert fields == expected_fields, f"Fields for {msg_name} differed"
+    expected_constants = expected_constants or {}
+    assert constants == expected_constants, f"Constants for {msg_name} differed"
+
+
+@pytest.mark.parametrize(
+    "msg_name, expected_fields, expected_constants",
+    [
+        (
+            "AudioPCM.msg",
+            [
+                ("builtin_interfaces/Time", "stamp"),
+                ("uint32", "sample_rate"),
+                ("uint8", "channels"),
+                ("uint8", "sample_format"),
+                ("uint32", "frame_index"),
+                ("uint8[]", "data"),
+            ],
+            {},
+        ),
+        (
+            "AudioChunk.msg",
+            [
+                ("builtin_interfaces/Time", "stamp_start"),
+                ("builtin_interfaces/Time", "stamp_end"),
+                ("string", "segment_id"),
+                ("uint32", "sequence"),
+                ("uint32", "sample_rate"),
+                ("uint8", "channels"),
+                ("uint8[]", "wav_data"),
+            ],
+            {},
+        ),
+        (
+            "AudioSegment.msg",
+            [
+                ("builtin_interfaces/Time", "stamp_start"),
+                ("builtin_interfaces/Time", "stamp_end"),
+                ("string", "segment_id"),
+                ("uint32", "sample_rate"),
+                ("uint8", "channels"),
+                ("uint8[]", "wav_data"),
+                ("bool", "cut_by_timeout"),
+            ],
+            {},
+        ),
+        (
+            "TranscriptPartial.msg",
+            [
+                ("string", "segment_id"),
+                ("uint32", "rev"),
+                ("builtin_interfaces/Time", "stamp_emitted"),
+                ("string", "text"),
+                ("float32", "confidence"),
+            ],
+            {},
+        ),
+        (
+            "TranscriptSegment.msg",
+            [
+                ("string", "segment_id"),
+                ("builtin_interfaces/Time", "segment_start"),
+                ("builtin_interfaces/Time", "segment_end"),
+                ("string", "text"),
+                ("float32", "confidence"),
+            ],
+            {},
+        ),
+        (
+            "TranscriptWhole.msg",
+            [
+                ("builtin_interfaces/Time", "stamp_emitted"),
+                ("uint32[]", "start_char"),
+                ("uint32[]", "end_char"),
+                ("string[]", "text"),
+            ],
+            {},
+        ),
+        (
+            "TranscriptEvent.msg",
+            [
+                ("builtin_interfaces/Time", "stamp_emitted"),
+                ("uint8", "kind"),
+                ("string", "payload_json"),
+            ],
+            {
+                "KIND_PARTIAL": ("uint8", "0"),
+                "KIND_FINAL": ("uint8", "1"),
+                "KIND_HQ_PATCH": ("uint8", "2"),
+            },
+        ),
+    ],
+)
+def test_message_signatures_are_locked_down(msg_name, expected_fields, expected_constants):
+    """Messages act as shared contracts; assert the committed schema."""
+
+    _assert_msg_signature(msg_name, expected_fields, expected_constants)


### PR DESCRIPTION
## Summary
- add message definitions for the audio pipeline and transcript flow described in the ROS topology
- update the interface package build to export the new message contracts
- capture the schemas in a pytest and document the numpy dependency for running the full suite

## Testing
- pytest tests/test_audio_interface_msgs.py

------
https://chatgpt.com/codex/tasks/task_e_68cc4862c1bc8320ac1da8022ac2f12c