### PR TITLE
⚡ Bolt: [performance improvement] Pre-allocate Numpy morph kernel in ObjectDetector

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2025-05-18 - Pre-allocate constant arrays in high-frequency callbacks
+**Learning:** In high-frequency ROS 2 callbacks (like vision processing `image_callback` -> `detect_object`), creating constant arrays like Numpy kernels `np.ones((5, 5), np.uint8)` on every frame adds up to noticeable overhead and triggers garbage collection.
+**Action:** Always pre-allocate constant objects in `__init__` and reuse them in the callback when the underlying library (like OpenCV) treats them as read-only.

--- a/src/psyche_vision/psyche_vision/object_detector.py
+++ b/src/psyche_vision/psyche_vision/object_detector.py
@@ -59,6 +59,10 @@ class ObjectDetector(Node):
             10
         )
         
+        # Pre-allocate kernel for morphological operations to avoid
+        # creating a new Numpy array on every camera frame (performance optimization)
+        self.morph_kernel = np.ones((5, 5), np.uint8)
+
         self.get_logger().info('Object detector started')
     
     def image_callback(self, msg):
@@ -106,9 +110,8 @@ class ObjectDetector(Node):
         mask = cv2.inRange(hsv, lower, upper)
         
         # Morphological operations to clean up mask
-        kernel = np.ones((5, 5), np.uint8)
-        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, kernel)
-        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, self.morph_kernel)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, self.morph_kernel)
         
         # Find contours
         contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)


### PR DESCRIPTION
💡 What: The Numpy kernel used for morphological operations `np.ones((5, 5), np.uint8)` has been moved from the `detect_object` method to the `ObjectDetector.__init__` method, storing it as `self.morph_kernel`.

🎯 Why: In a high-frequency ROS 2 CV callback, repeatedly allocating a new Numpy array on every frame adds up to noticeable overhead and triggers garbage collection. Pre-allocating this array because it acts as a read-only structuring element for `cv2.morphologyEx` avoids this per-frame allocation cost.

📊 Impact: Reduces memory allocation and GC overhead per camera frame. While a micro-optimization on its own, it sets a good standard for the hot path of the CV vision processing node.

🔬 Measurement: Since it's a micro-optimization in a high-frequency Python node, you can observe decreased memory allocation/GC jitter when processing sustained image streams using Python profiling tools like `cProfile` or memory profilers.

---
*PR created automatically by Jules for task [9883647669919276778](https://jules.google.com/task/9883647669919276778) started by @dancxjo*