### PR TITLE
🎨 Palette: CLI Help Output Grouping

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - CLI Help Output Grouping
+**Learning:** Terminal CLI users parse large blocks of available commands much faster when commands are logically grouped under colored headings.
+**Action:** Use ANSI color codes and blank lines to separate logic groupings (like Operations, Services, Systemd, Tools) in CLI scripts like `cli/psy` to reduce cognitive load when navigating the tool.

--- a/cli/psy
+++ b/cli/psy
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+C_RESET=$'\033[0m'
+C_INFO=$'\033[1;34m'
+C_SUCCESS=$'\033[1;32m'
+C_WARN=$'\033[1;33m'
+C_ERROR=$'\033[1;31m'
+C_HEADER=$'\033[1;36m'
+
+log_info() { echo "${C_INFO}[psy]${C_RESET} $*"; }
+log_success() { echo "${C_SUCCESS}[psy]${C_RESET} $*"; }
+log_warn() { echo "${C_WARN}[psy] WARN:${C_RESET} $*" >&2; }
+log_error() { echo "${C_ERROR}[psy] ERROR:${C_RESET} $*" >&2; }
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 DEFAULT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd -P)"
 if [ -n "${PSY_ROOT:-}" ] && [ -d "${PSY_ROOT%/}/provision/services" ]; then
@@ -72,29 +84,35 @@ merge_legacy_workspace() {
 
 usage() {
   cat <<USAGE
-psy — psycheOS host/service manager
+${C_HEADER}psy${C_RESET} — psycheOS host/service manager
 
-Usage:
+${C_HEADER}Operations${C_RESET}
   psy bring up [svc..]        Start named services via systemd (defaults to all)
   psy bring down [svc..]      Stop named services via systemd (defaults to all)
   psy bring restart [svc..]   Restart named services via systemd (defaults to all)
   psy bring status [svc..]    Show brief status for named services (defaults to all)
   psy debug [svc..]           Show systemd summary plus recent logs
+  psy build                    colcon build (creates ws if needed)
+  psy update                   Reinstall latest psyche from GitHub and re-apply
+
+${C_HEADER}Services${C_RESET}
   psy host apply [<host>]      Apply host's service set (defaults to $(hostname))
   psy svc list                 List available services
   psy svc enable <name>        Enable a service for this host
   psy svc disable <name>       Disable a service for this host
-  psy build                    colcon build (creates ws if needed)
-  psy bringup nav              Launch nav2 stack (tmux/screen-less; use systemd)
-  psy bringup create           Launch iRobot Create base bringup (create_bringup create_1.launch)
+
+${C_HEADER}Systemd${C_RESET}
   psy systemd install          Install per-service systemd units and enable configured ones
   psy systemd info [svc..]    Show systemd summary (and recent logs for named services)
   psy systemd up               Start all enabled service units now
   psy systemd down             Stop all service units
-  psy update                   Reinstall latest psyche from GitHub and re-apply
+
+${C_HEADER}Tools${C_RESET}
+  psy bringup nav              Launch nav2 stack (tmux/screen-less; use systemd)
+  psy bringup create           Launch iRobot Create base bringup (create_bringup create_1.launch)
   psy say <text>               Publish text to /voice/$(hostname -s)
 
-Helper:
+${C_HEADER}Helper${C_RESET}
   psh say <text>               Convenience wrapper to publish to /voice/$(hostname -s)
   psh bearing <deg>            Publish /cmd_vel Twist to rotate toward the bearing
 USAGE


### PR DESCRIPTION
🎨 Palette: CLI Help Output Grouping

💡 What:
Reorganized the `usage()` output in `cli/psy` to group available commands into logical categories (Operations, Services, Systemd, Tools, Helper). Added ANSI color headers and standardized logging helper functions. Also created a new `.Jules/palette.md` file to journal this accessibility/UX insight.

🎯 Why:
Terminal CLI users parse large blocks of available commands much faster when commands are logically grouped under colored headings. This reduces cognitive load when navigating the `psy` tool.

♿ Accessibility:
Improved visual scanability for users exploring the CLI options.

---
*PR created automatically by Jules for task [8032512818702482915](https://jules.google.com/task/8032512818702482915) started by @dancxjo*