### PR TITLE
⚡ Bolt: Pre-allocate morphology kernel in object_detector.py

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-18 - Pre-allocating Numpy Arrays in High-Frequency Callbacks
+**Learning:** Instantiating Numpy arrays (like morphological kernels `np.ones(...)`) inside high-frequency ROS 2 callbacks (e.g., vision processing at 30+ FPS) adds measurable memory allocation overhead and triggers more frequent garbage collection.
+**Action:** Always pre-allocate constant objects (like Numpy kernels) in `__init__` and reuse them across frames when working with high-frequency topics.

--- a/src/psyche_vision/psyche_vision/object_detector.py
+++ b/src/psyche_vision/psyche_vision/object_detector.py
@@ -31,6 +31,9 @@ class ObjectDetector(Node):
         # Initialize CV bridge
         self.bridge = CvBridge()
         
+        # Pre-allocate morphology kernel to avoid per-frame allocation overhead
+        self.morph_kernel = np.ones((5, 5), np.uint8)
+
         # Publishers and subscribers
         self.image_sub = self.create_subscription(
             Image, 
@@ -106,9 +109,8 @@ class ObjectDetector(Node):
         mask = cv2.inRange(hsv, lower, upper)
         
         # Morphological operations to clean up mask
-        kernel = np.ones((5, 5), np.uint8)
-        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, kernel)
-        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, self.morph_kernel)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, self.morph_kernel)
         
         # Find contours
         contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)


### PR DESCRIPTION
💡 What: Moved the instantiation of the `np.ones((5, 5), np.uint8)` morphological kernel out of the per-frame `detect_object` function and pre-allocated it in the `ObjectDetector` class's `__init__`.
🎯 Why: In high-frequency ROS 2 callbacks (like parsing video frames at 30+ FPS), constantly instantiating Numpy arrays adds unnecessary memory allocation overhead and triggers more frequent garbage collection, slowing down the vision pipeline.
📊 Impact: Reduces per-frame memory allocation overhead by reusing a static kernel matrix. Over thousands of frames, this decreases garbage collection pressure and makes processing times slightly more consistent.
🔬 Measurement: Run `python3 src/psyche_vision/test_vision.py` to ensure core vision logic still passes, and observe system memory footprint/GC pauses over long-running sessions.

---
*PR created automatically by Jules for task [3776694361447380133](https://jules.google.com/task/3776694361447380133) started by @dancxjo*