### PR TITLE
🎨 Palette: [UX improvement] - Group CLI commands logically and add ANSI colors

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-03-03 - CLI Developer Experience (DX) Improvements
+**Learning:** Dense walls of unformatted text in command-line tool outputs are difficult to parse and slow down developer workflows. By logically grouping commands (e.g., Services, Operations, Systemd, Tools) and applying standardized ANSI color formatting, legibility and overall DX are significantly improved. Using bash ANSI-C quoting (`$'\033[...'`) ensures consistent cross-environment interpolation, especially within heredocs.
+**Action:** When working on CLI utilities, always implement semantic log helpers (`log_info`, `log_success`, `log_error`) and logical formatting groups to guide users. Avoid generic echo statements for structured tool outputs.

--- a/cli/psy
+++ b/cli/psy
@@ -19,6 +19,18 @@ SVCDIR="$PROV/services"
 WS="$ROOT/ws"
 . "$SVCDIR/_common.sh" 2>/dev/null || true
 
+C_INFO=$'\033[1;34m'
+C_SUCCESS=$'\033[1;32m'
+C_WARN=$'\033[1;33m'
+C_ERROR=$'\033[1;31m'
+C_RESET=$'\033[0m'
+C_BOLD=$'\033[1m'
+
+log_info() { echo "${C_INFO}[psy]${C_RESET} $*"; }
+log_success() { echo "${C_SUCCESS}[psy]${C_RESET} $*"; }
+log_warn() { echo "${C_WARN}[psy] WARN:${C_RESET} $*" >&2; }
+log_error() { echo "${C_ERROR}[psy] ERROR:${C_RESET} $*" >&2; }
+
 # Merge helper: consolidate legacy /opt/ros2_ws into $WS and replace with symlink.
 # Idempotent: if /opt/ros2_ws is already a symlink pointing at $WS, nothing happens.
 merge_legacy_workspace() {
@@ -72,30 +84,37 @@ merge_legacy_workspace() {
 
 usage() {
   cat <<USAGE
-psy — psycheOS host/service manager
+${C_BOLD}psy — psycheOS host/service manager${C_RESET}
 
-Usage:
+${C_INFO}Services${C_RESET}
+  psy svc list                 List available services
+  psy svc enable <name>        Enable a service for this host
+  psy svc disable <name>       Disable a service for this host
+
+${C_INFO}Operations${C_RESET}
+  psy host apply [<host>]      Apply host's service set (defaults to \$(hostname))
+  psy build                    colcon build (creates ws if needed)
+  psy bringup nav              Launch nav2 stack (tmux/screen-less; use systemd)
+  psy bringup create           Launch iRobot Create base bringup (create_bringup create_1.launch)
   psy bring up [svc..]        Start named services via systemd (defaults to all)
   psy bring down [svc..]      Stop named services via systemd (defaults to all)
   psy bring restart [svc..]   Restart named services via systemd (defaults to all)
   psy bring status [svc..]    Show brief status for named services (defaults to all)
-  psy debug [svc..]           Show systemd summary plus recent logs
-  psy host apply [<host>]      Apply host's service set (defaults to $(hostname))
-  psy svc list                 List available services
-  psy svc enable <name>        Enable a service for this host
-  psy svc disable <name>       Disable a service for this host
-  psy build                    colcon build (creates ws if needed)
-  psy bringup nav              Launch nav2 stack (tmux/screen-less; use systemd)
-  psy bringup create           Launch iRobot Create base bringup (create_bringup create_1.launch)
+
+${C_INFO}Systemd${C_RESET}
   psy systemd install          Install per-service systemd units and enable configured ones
   psy systemd info [svc..]    Show systemd summary (and recent logs for named services)
   psy systemd up               Start all enabled service units now
   psy systemd down             Stop all service units
-  psy update                   Reinstall latest psyche from GitHub and re-apply
-  psy say <text>               Publish text to /voice/$(hostname -s)
 
-Helper:
-  psh say <text>               Convenience wrapper to publish to /voice/$(hostname -s)
+${C_INFO}Tools${C_RESET}
+  psy debug [svc..]           Show systemd summary plus recent logs
+  psy update                   Reinstall latest psyche from GitHub and re-apply
+  psy say <text>               Publish text to /voice/\$(hostname -s)
+  psy bearing <deg>            Compute and publish /cmd_vel Twist to rotate toward the bearing
+
+${C_INFO}Helper${C_RESET}
+  psh say <text>               Convenience wrapper to publish to /voice/\$(hostname -s)
   psh bearing <deg>            Publish /cmd_vel Twist to rotate toward the bearing
 USAGE
 }


### PR DESCRIPTION
🎨 Palette: Improved CLI developer experience
💡 What: Added ANSI color formatting to the `psy` CLI usage text and logically grouped commands into Services, Operations, Systemd, Tools, and Helper.
🎯 Why: Dense walls of text are hard to read. Structuring the help menu and highlighting section headers improves legibility and discoverability for developers using the command-line interface.
♿ Accessibility: Increased visual hierarchy and contrast for standard text output.

---
*PR created automatically by Jules for task [13268702725495558688](https://jules.google.com/task/13268702725495558688) started by @dancxjo*