### PR TITLE
⚡ Bolt: optimize morphological kernel allocation in object detector

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Pre-allocate Constant Objects in ROS 2 Callbacks
+**Learning:** High-frequency ROS 2 image callbacks suffer from increased memory allocation overhead and GC pauses when instantiating constant arrays (like morphological kernels via `np.ones`) on every frame.
+**Action:** Always pre-allocate constant arrays or objects in the `__init__` method of the node and reuse them across callback invocations to minimize per-frame overhead.

--- a/src/psyche_vision/psyche_vision/object_detector.py
+++ b/src/psyche_vision/psyche_vision/object_detector.py
@@ -59,6 +59,10 @@ class ObjectDetector(Node):
             10
         )
         
+        # Performance optimization: pre-allocate morphological kernel
+        # to prevent reallocation on every frame
+        self.morph_kernel = np.ones((5, 5), np.uint8)
+
         self.get_logger().info('Object detector started')
     
     def image_callback(self, msg):
@@ -106,9 +110,9 @@ class ObjectDetector(Node):
         mask = cv2.inRange(hsv, lower, upper)
         
         # Morphological operations to clean up mask
-        kernel = np.ones((5, 5), np.uint8)
-        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, kernel)
-        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel)
+        # Using pre-allocated kernel to avoid allocation per-frame
+        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, self.morph_kernel)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, self.morph_kernel)
         
         # Find contours
         contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)


### PR DESCRIPTION
💡 **What:**
Pre-allocated the morphological kernel array (`np.ones((5, 5), np.uint8)`) as a class attribute (`self.morph_kernel`) during the `ObjectDetector` initialization, instead of re-instantiating it on every frame inside the `detect_object` method. Added a learning regarding this to `.jules/bolt.md`.

🎯 **Why:**
High-frequency computer vision loops within ROS 2 callbacks can suffer from memory allocation overhead and unnecessary garbage collection (GC) pauses when creating and destroying NumPy arrays continually. Reusing a constant kernel is safer and faster.

📊 **Impact:**
Reduces per-frame memory allocation overhead inside `cv2.morphologyEx`. Helps maintain stable CPU usage and framerate without triggering frequent GC sweeps.

🔬 **Measurement:**
No functional change, operations perform identically. The functionality was verified by running `pytest src/psyche_vision/test_vision.py`, which continues to pass.

---
*PR created automatically by Jules for task [10916793843639393834](https://jules.google.com/task/10916793843639393834) started by @dancxjo*