### PR TITLE
🎨 Palette: Enhance `psy` CLI usage UX with organized groups and colors

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Bash CLI UX Enhancements and Heredoc Parsing
+**Learning:** Organizing CLI help output with visual groups and color-coding significantly improves readability. However, when defining color variables using ANSI-C quoting in bash, they must be used carefully inside heredocs. Also, dynamic command substitutions like `\$(hostname)` must be escaped inside unquoted heredocs to prevent them from executing at parsing time, preventing syntax errors and unexpected behavior.
+**Action:** When designing bash CLI help messages, use structured groups and standardized ANSI variables. Always double-check heredoc parsing behavior and ensure any dynamic substitutions are properly escaped (`\$`) if they are meant to be displayed as examples rather than executed.

--- a/cli/psy
+++ b/cli/psy
@@ -19,6 +19,23 @@ SVCDIR="$PROV/services"
 WS="$ROOT/ws"
 . "$SVCDIR/_common.sh" 2>/dev/null || true
 
+# ANSI Color helpers
+C_RESET=""
+C_BOLD=""
+C_INFO=""
+C_SUCCESS=""
+C_WARN=""
+C_ERROR=""
+
+if [ -t 1 ]; then
+  C_RESET=$'\033[0m'
+  C_BOLD=$'\033[1m'
+  C_INFO=$'\033[1;34m'
+  C_SUCCESS=$'\033[1;32m'
+  C_WARN=$'\033[1;33m'
+  C_ERROR=$'\033[1;31m'
+fi
+
 # Merge helper: consolidate legacy /opt/ros2_ws into $WS and replace with symlink.
 # Idempotent: if /opt/ros2_ws is already a symlink pointing at $WS, nothing happens.
 merge_legacy_workspace() {
@@ -72,29 +89,35 @@ merge_legacy_workspace() {
 
 usage() {
   cat <<USAGE
-psy — psycheOS host/service manager
+${C_BOLD}psy — psycheOS host/service manager${C_RESET}
 
-Usage:
+${C_INFO}Services${C_RESET}
+  psy svc list                 List available services
+  psy svc enable <name>        Enable a service for this host
+  psy svc disable <name>       Disable a service for this host
+
+${C_INFO}Operations${C_RESET}
   psy bring up [svc..]        Start named services via systemd (defaults to all)
   psy bring down [svc..]      Stop named services via systemd (defaults to all)
   psy bring restart [svc..]   Restart named services via systemd (defaults to all)
   psy bring status [svc..]    Show brief status for named services (defaults to all)
   psy debug [svc..]           Show systemd summary plus recent logs
-  psy host apply [<host>]      Apply host's service set (defaults to $(hostname))
-  psy svc list                 List available services
-  psy svc enable <name>        Enable a service for this host
-  psy svc disable <name>       Disable a service for this host
-  psy build                    colcon build (creates ws if needed)
-  psy bringup nav              Launch nav2 stack (tmux/screen-less; use systemd)
-  psy bringup create           Launch iRobot Create base bringup (create_bringup create_1.launch)
+  psy say <text>               Publish text to /voice/$(hostname -s)
+
+${C_INFO}Systemd${C_RESET}
   psy systemd install          Install per-service systemd units and enable configured ones
   psy systemd info [svc..]    Show systemd summary (and recent logs for named services)
   psy systemd up               Start all enabled service units now
   psy systemd down             Stop all service units
-  psy update                   Reinstall latest psyche from GitHub and re-apply
-  psy say <text>               Publish text to /voice/$(hostname -s)
 
-Helper:
+${C_INFO}Tools${C_RESET}
+  psy host apply [<host>]      Apply host's service set (defaults to $(hostname))
+  psy build                    colcon build (creates ws if needed)
+  psy bringup nav              Launch nav2 stack (tmux/screen-less; use systemd)
+  psy bringup create           Launch iRobot Create base bringup (create_bringup create_1.launch)
+  psy update                   Reinstall latest psyche from GitHub and re-apply
+
+${C_INFO}Helper${C_RESET}
   psh say <text>               Convenience wrapper to publish to /voice/$(hostname -s)
   psh bearing <deg>            Publish /cmd_vel Twist to rotate toward the bearing
 USAGE


### PR DESCRIPTION
🎨 Palette: [UX improvement]

💡 **What:** Added conditional ANSI color variables and categorized the help commands into logical groups (Services, Operations, Systemd, Tools, Helper) in the `psy` CLI script. Also added a journal entry regarding bash TTY color handling and heredocs.

🎯 **Why:** The previous CLI output was a flat, uncolored list of commands. By grouping them logically and applying standard ANSI color highlights (only when attached to a TTY so as not to pollute piped output), the tool becomes significantly more scannable and pleasant to use.

📸 **Before/After:** The help output changes from a flat text block to a highlighted, grouped, and spaced interface.

♿ **Accessibility:** Visually separates the different areas of operation, lowering the cognitive load required to find a specific command in the terminal.

---
*PR created automatically by Jules for task [17264935677967641922](https://jules.google.com/task/17264935677967641922) started by @dancxjo*