### PR TITLE
⚡ Bolt: Pre-allocate morphology kernel and optimize inner loops in vision ObjectDetector

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,6 @@
+## 2024-05-24 - High-Frequency Loop Optimizations in ROS 2 Vision Nodes
+
+**Learning:** In high-frequency loops (e.g., image processing callbacks like `ObjectDetector`), creating objects repeatedly (like `np.ones((5, 5), np.uint8)` for morphology kernels) causes unnecessary memory allocation and garbage collection overhead. Pre-allocating these constants in `__init__` is a better performance pattern.
+Furthermore, within the inner loop of contour processing, checking `if area > min_area and area > largest_area:` evaluates two conditions per contour. By initializing `largest_area = min_area` instead of `0` before the loop, we can simplify the condition to just `if area > largest_area:`, thereby halving the number of conditional checks in the hot path.
+
+**Action:** Whenever writing or reviewing vision nodes or other high-frequency callbacks, look for static arrays or constants defined inside the loop/callback and move them to `__init__`. Additionally, inspect loops searching for extrema (e.g., maximum size) and initialize tracking variables to the minimum threshold to reduce conditional branch count inside the loop.

--- a/src/psyche_vision/psyche_vision/object_detector.py
+++ b/src/psyche_vision/psyche_vision/object_detector.py
@@ -59,6 +59,9 @@ class ObjectDetector(Node):
             10
         )
         
+        # Pre-allocate kernel for morphology operations (Performance: avoids memory allocation in loop)
+        self.morph_kernel = np.ones((5, 5), np.uint8)
+
         self.get_logger().info('Object detector started')
     
     def image_callback(self, msg):
@@ -105,10 +108,9 @@ class ObjectDetector(Node):
         # Create mask for target color
         mask = cv2.inRange(hsv, lower, upper)
         
-        # Morphological operations to clean up mask
-        kernel = np.ones((5, 5), np.uint8)
-        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, kernel)
-        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel)
+        # Morphological operations to clean up mask (using pre-allocated kernel)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, self.morph_kernel)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, self.morph_kernel)
         
         # Find contours
         contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
@@ -117,12 +119,13 @@ class ObjectDetector(Node):
             return None, None, 0.0
         
         # Find largest contour that meets minimum area requirement
+        # Initialize largest_area to min_area to reduce conditional branch count within loop
         largest_contour = None
-        largest_area = 0
+        largest_area = min_area
         
         for contour in contours:
             area = cv2.contourArea(contour)
-            if area > min_area and area > largest_area:
+            if area > largest_area:
                 largest_area = area
                 largest_contour = contour
         


### PR DESCRIPTION
💡 What:
- Pre-allocated the numpy array used for the morphology kernel `np.ones((5, 5), np.uint8)` in `ObjectDetector.__init__` rather than re-creating it on every single frame in `detect_object`.
- Initialized `largest_area = min_area` instead of `0` in the contour iteration loop. This allowed changing `if area > min_area and area > largest_area:` to a simpler `if area > largest_area:`, evaluating half as many conditions per contour.
- Documented these optimizations in `.jules/bolt.md`

🎯 Why:
The `ObjectDetector` is part of the vision pipeline and processes high-frequency images. Re-allocating static memory inside this tight loop causes unnecessary garbage collection and processing overhead. Similarly, evaluating redundant conditionals inside the hot path wastes CPU cycles.

📊 Impact:
- Reduces memory allocations per frame by 1 array.
- Halves the number of conditional checks executed per contour found.

🔬 Measurement:
1. Run `python3 src/psyche_vision/test_vision.py` to ensure core computation logic remains intact.
2. Run `pytest` across the repo to verify no regressions were introduced.

---
*PR created automatically by Jules for task [15321026061501035001](https://jules.google.com/task/15321026061501035001) started by @dancxjo*