### PR TITLE
⚡ Bolt: Optimize vision object detector loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-05-24 - Optimizing Python CV/Vision loops
+**Learning:** In high-frequency CV/vision loops (like `ObjectDetector`), creating objects inside the loop (like `np.ones` for morphology kernels) causes redundant memory allocations which are slow. In addition, nested condition checks inside contour loops (e.g. `if area > min_area and area > largest_area`) can be eliminated by initializing search variables cleverly (e.g. `largest_area = min_area`).
+**Action:** Always pre-allocate static arrays/kernels in class `__init__` methods for any high-frequency loops. Identify and optimize branch predictions within performance-critical algorithms.

--- a/src/psyche_vision/psyche_vision/object_detector.py
+++ b/src/psyche_vision/psyche_vision/object_detector.py
@@ -28,6 +28,9 @@ class ObjectDetector(Node):
         self.declare_parameter('camera_fov_degrees', 60.0)  # Camera field of view
         self.declare_parameter('publish_target_point', True)  # Also publish /target_point
         
+        # Pre-allocate kernel for morphology operations to save memory allocations in loop
+        self.morph_kernel = np.ones((5, 5), np.uint8)
+
         # Initialize CV bridge
         self.bridge = CvBridge()
         
@@ -106,9 +109,8 @@ class ObjectDetector(Node):
         mask = cv2.inRange(hsv, lower, upper)
         
         # Morphological operations to clean up mask
-        kernel = np.ones((5, 5), np.uint8)
-        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, kernel)
-        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, self.morph_kernel)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, self.morph_kernel)
         
         # Find contours
         contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
@@ -117,12 +119,13 @@ class ObjectDetector(Node):
             return None, None, 0.0
         
         # Find largest contour that meets minimum area requirement
+        # Initialize largest_area with min_area to eliminate branch conditional inside the loop
         largest_contour = None
-        largest_area = 0
+        largest_area = min_area
         
         for contour in contours:
             area = cv2.contourArea(contour)
-            if area > min_area and area > largest_area:
+            if area > largest_area:
                 largest_area = area
                 largest_contour = contour
         


### PR DESCRIPTION
What:
1. Pre-allocated morphological kernel in `__init__` rather than recreating it on every frame inside `detect_object`.
2. Initialized `largest_area = min_area` to remove the redundant `area > min_area` conditional check inside the contour iteration loop.

Why:
In high-frequency CV/vision loops (like `ObjectDetector`), creating objects inside the loop (like `np.ones` for morphology kernels) causes redundant memory allocations which are slow. In addition, nested condition checks inside contour loops can be eliminated by initializing search variables cleverly. These micro-optimizations compound effectively over a 10+ Hz loop.

Impact:
Measurable reduction in garbage collection pressure and memory allocations per frame. Slightly faster execution per frame due to one fewer branch instruction evaluated per image contour.

Measurement:
Run `pytest src/psyche_vision/test_vision.py` to verify the mathematical bearing logic remains sound, and visually monitor CPU usage during robot operation with the debug image publisher disabled.

---
*PR created automatically by Jules for task [5515053224378634912](https://jules.google.com/task/5515053224378634912) started by @dancxjo*