### PR TITLE
🎨 Palette: Refactor psy CLI help layout and colors

### DIFF
--- a/cli/psy
+++ b/cli/psy
@@ -71,30 +71,47 @@ merge_legacy_workspace() {
 }
 
 usage() {
+  local c_reset="" c_bold="" c_blue="" c_green="" c_yellow=""
+  if [ -t 1 ]; then
+    c_reset=$'\E[0m'
+    c_bold=$'\E[1m'
+    c_blue=$'\E[34m'
+    c_green=$'\E[32m'
+    c_yellow=$'\E[33m'
+  fi
+
   cat <<USAGE
-psy — psycheOS host/service manager
+${c_bold}${c_blue}psy${c_reset} — psycheOS host/service manager
 
-Usage:
-  psy bring up [svc..]        Start named services via systemd (defaults to all)
-  psy bring down [svc..]      Stop named services via systemd (defaults to all)
-  psy bring restart [svc..]   Restart named services via systemd (defaults to all)
-  psy bring status [svc..]    Show brief status for named services (defaults to all)
-  psy debug [svc..]           Show systemd summary plus recent logs
-  psy host apply [<host>]      Apply host's service set (defaults to $(hostname))
-  psy svc list                 List available services
-  psy svc enable <name>        Enable a service for this host
-  psy svc disable <name>       Disable a service for this host
-  psy build                    colcon build (creates ws if needed)
-  psy bringup nav              Launch nav2 stack (tmux/screen-less; use systemd)
-  psy bringup create           Launch iRobot Create base bringup (create_bringup create_1.launch)
-  psy systemd install          Install per-service systemd units and enable configured ones
-  psy systemd info [svc..]    Show systemd summary (and recent logs for named services)
-  psy systemd up               Start all enabled service units now
-  psy systemd down             Stop all service units
-  psy update                   Reinstall latest psyche from GitHub and re-apply
-  psy say <text>               Publish text to /voice/$(hostname -s)
+${c_bold}Usage:${c_reset}
 
-Helper:
+  ${c_yellow}Services${c_reset}
+    psy bring up [svc..]        Start named services via systemd (defaults to all)
+    psy bring down [svc..]      Stop named services via systemd (defaults to all)
+    psy bring restart [svc..]   Restart named services via systemd (defaults to all)
+    psy bring status [svc..]    Show brief status for named services (defaults to all)
+    psy svc list                 List available services
+    psy svc enable <name>        Enable a service for this host
+    psy svc disable <name>       Disable a service for this host
+
+  ${c_yellow}Operations${c_reset}
+    psy host apply [<host>]      Apply host's service set (defaults to $(hostname))
+    psy build                    colcon build (creates ws if needed)
+    psy update                   Reinstall latest psyche from GitHub and re-apply
+    psy bringup nav              Launch nav2 stack (tmux/screen-less; use systemd)
+    psy bringup create           Launch iRobot Create base bringup (create_bringup create_1.launch)
+
+  ${c_yellow}Systemd${c_reset}
+    psy systemd install          Install per-service systemd units and enable configured ones
+    psy systemd info [svc..]    Show systemd summary (and recent logs for named services)
+    psy systemd up               Start all enabled service units now
+    psy systemd down             Stop all service units
+    psy debug [svc..]           Show systemd summary plus recent logs
+
+  ${c_yellow}Tools${c_reset}
+    psy say <text>               Publish text to /voice/$(hostname -s)
+
+${c_bold}Helper:${c_reset}
   psh say <text>               Convenience wrapper to publish to /voice/$(hostname -s)
   psh bearing <deg>            Publish /cmd_vel Twist to rotate toward the bearing
 USAGE


### PR DESCRIPTION
💡 What: Added command categorization (Services, Operations, Systemd, Tools) and conditional ANSI color highlighting to the `psy` CLI usage text.
🎯 Why: Makes the long list of CLI commands much easier to scan visually.
📸 Before/After: NA (text output changed from plain list to a structured list).
♿ Accessibility: Colors are only output conditionally (`[ -t 1 ]`) to ensure piping and log redirection still work cleanly without emitting garbage control characters.

---
*PR created automatically by Jules for task [12957877785568680420](https://jules.google.com/task/12957877785568680420) started by @dancxjo*