### PR TITLE
🎨 Palette: [Improve CLI help message UX and readability]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - CLI Usage Formatting
+**Learning:** In bash scripts like `cli/psy`, define ANSI color variables using bash ANSI-C quoting and conditionally apply them using `if [ -t 1 ]; then` to prevent garbage characters from appearing when the output is piped.
+**Action:** Apply this pattern when designing bash CLI help messages, and group commands logically for improved CLI UX.

--- a/cli/psy
+++ b/cli/psy
@@ -71,32 +71,48 @@ merge_legacy_workspace() {
 }
 
 usage() {
+  local b='' c='' y='' g='' r=''
+  if [ -t 1 ]; then
+    b=$'\033[1m'
+    c=$'\033[36m'
+    y=$'\033[33m'
+    g=$'\033[32m'
+    r=$'\033[0m'
+  fi
+
   cat <<USAGE
-psy — psycheOS host/service manager
+${b}${c}psy${r} — psycheOS host/service manager
 
-Usage:
-  psy bring up [svc..]        Start named services via systemd (defaults to all)
-  psy bring down [svc..]      Stop named services via systemd (defaults to all)
-  psy bring restart [svc..]   Restart named services via systemd (defaults to all)
-  psy bring status [svc..]    Show brief status for named services (defaults to all)
-  psy debug [svc..]           Show systemd summary plus recent logs
-  psy host apply [<host>]      Apply host's service set (defaults to $(hostname))
-  psy svc list                 List available services
-  psy svc enable <name>        Enable a service for this host
-  psy svc disable <name>       Disable a service for this host
-  psy build                    colcon build (creates ws if needed)
-  psy bringup nav              Launch nav2 stack (tmux/screen-less; use systemd)
-  psy bringup create           Launch iRobot Create base bringup (create_bringup create_1.launch)
-  psy systemd install          Install per-service systemd units and enable configured ones
-  psy systemd info [svc..]    Show systemd summary (and recent logs for named services)
-  psy systemd up               Start all enabled service units now
-  psy systemd down             Stop all service units
-  psy update                   Reinstall latest psyche from GitHub and re-apply
-  psy say <text>               Publish text to /voice/$(hostname -s)
+${b}Usage:${r}
+  ${y}Services${r}
+    ${g}psy host apply [<host>]${r}      Apply host's service set (defaults to $(hostname))
+    ${g}psy svc list${r}                 List available services
+    ${g}psy svc enable <name>${r}        Enable a service for this host
+    ${g}psy svc disable <name>${r}       Disable a service for this host
 
-Helper:
-  psh say <text>               Convenience wrapper to publish to /voice/$(hostname -s)
-  psh bearing <deg>            Publish /cmd_vel Twist to rotate toward the bearing
+  ${y}Operations${r}
+    ${g}psy bring up [svc..]${r}        Start named services via systemd (defaults to all)
+    ${g}psy bring down [svc..]${r}      Stop named services via systemd (defaults to all)
+    ${g}psy bring restart [svc..]${r}   Restart named services via systemd (defaults to all)
+    ${g}psy bring status [svc..]${r}    Show brief status for named services (defaults to all)
+
+  ${y}Systemd${r}
+    ${g}psy debug [svc..]${r}           Show systemd summary plus recent logs
+    ${g}psy systemd install${r}          Install per-service systemd units and enable configured ones
+    ${g}psy systemd info [svc..]${r}    Show systemd summary (and recent logs for named services)
+    ${g}psy systemd up${r}               Start all enabled service units now
+    ${g}psy systemd down${r}             Stop all service units
+
+  ${y}Tools${r}
+    ${g}psy build${r}                    colcon build (creates ws if needed)
+    ${g}psy bringup nav${r}              Launch nav2 stack (tmux/screen-less; use systemd)
+    ${g}psy bringup create${r}           Launch iRobot Create base bringup (create_bringup create_1.launch)
+    ${g}psy update${r}                   Reinstall latest psyche from GitHub and re-apply
+    ${g}psy say <text>${r}               Publish text to /voice/$(hostname -s)
+
+  ${y}Helper${r}
+    ${g}psh say <text>${r}               Convenience wrapper to publish to /voice/$(hostname -s)
+    ${g}psh bearing <deg>${r}            Publish /cmd_vel Twist to rotate toward the bearing
 USAGE
 }
 


### PR DESCRIPTION
💡 **What:** Categorized the `psy` CLI help menu into logical groups (Services, Operations, Systemd, Tools) and added conditional ANSI coloring.
🎯 **Why:** To make the CLI tool significantly easier to scan and visually parse for operators. The previous block of text made finding specific commands difficult.
📸 **Before/After:** The plain text block is now a structured, highlighted list. 
♿ **Accessibility:** The ANSI colors are strictly wrapped in `if [ -t 1 ]; then`, meaning that if the output is piped, grep'd, or redirected to a file, the color codes are completely disabled, preventing garbage characters from breaking downstream tools or screen readers reading raw output files. Added a critical learning to `.Jules/palette.md` noting this Bash interaction pattern.

---
*PR created automatically by Jules for task [12537374473547547523](https://jules.google.com/task/12537374473547547523) started by @dancxjo*