### PR TITLE
⚡ Bolt: Optimize PCM16 energy calculation in microphone VAD

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-12 - Fast PCM16 Energy Calculation
+**Learning:** In Python audio processing on resource-constrained devices, calculating audio energy via explicit `struct.unpack_from` loops is extremely slow due to the overhead of thousands of function calls and tuple unpacks per frame. The `audioop.rms` function would be fast but is deprecated/removed in Python 3.13. Using `array.array('h', frame)` and `sum(map(abs, ...))` provides a massive performance boost by pushing the loop into C, without requiring heavy dependencies like NumPy.
+**Action:** When calculating PCM16 energy or RMS in Python where NumPy is forbidden, replace `struct` loops with `array.array('h')` combined with built-ins like `sum` and `map`.

--- a/provision/services/mic_node.py
+++ b/provision/services/mic_node.py
@@ -49,6 +49,7 @@ import sys
 import threading
 import time
 import wave
+import array
 from typing import Deque, Iterable, List, Optional
 
 try:  # pragma: no cover - optional dependency
@@ -569,11 +570,10 @@ class MicVADNode(Node):
         if not frame:
             return False
         count = len(frame) // 2
-        # Unpack shorts; to keep cheap avoid numpy
-        energy = 0
-        for i in range(count):
-            (sample,) = struct.unpack_from('<h', frame, i * 2)
-            energy += abs(sample)
+        # Unpack shorts; to keep cheap avoid numpy.
+        # array.array + sum is much faster than struct loop
+        samples = array.array('h', frame)
+        energy = sum(map(abs, samples))
         avg = energy / max(1, count)
         active = avg > self._energy_threshold
         if active:


### PR DESCRIPTION
💡 What: Replaced the slow `struct.unpack_from` loop in `MicVADNode._detect_voice` with `array.array('h')` and `sum(map(abs, ...))`.
🎯 Why: Python-level for-loops calling `unpack_from` thousands of times per frame represent a significant performance bottleneck for audio processing on resource-constrained devices like the Pi 5. Using `array.array` pushes the iteration loop down into C level.
📊 Impact: Considerably faster computation of audio energy, reducing CPU overhead per frame without introducing heavy dependencies like NumPy.
🔬 Measurement: Verify by measuring CPU usage of the `psy_mic_vad` node while injecting audio, or by inspecting test suite execution times (the logic remains 100% compliant with existing tests in `test_mic_vad_energy.py`).

---
*PR created automatically by Jules for task [11129088165576610824](https://jules.google.com/task/11129088165576610824) started by @dancxjo*